### PR TITLE
feat: when customer created from lead, dont update lead status

### DIFF
--- a/erpnext_china_mdm/mdm/custom_form_script/customer.py
+++ b/erpnext_china_mdm/mdm/custom_form_script/customer.py
@@ -5,11 +5,19 @@ import frappe
 from erpnext.selling.doctype.customer.customer import Customer
 
 class CustomCustomer(Customer):
-    
-    def validate(self):
-        super().validate()
-        self.clean_fields()
+	
+	def validate(self):
+		super().validate()
+		self.clean_fields()
 
-    def clean_fields(self):
-        if self.customer_name:
-            self.customer_name = str(self.customer_name).replace(' ', '')
+	def clean_fields(self):
+		if self.customer_name:
+			self.customer_name = str(self.customer_name).replace(' ', '')
+	
+	# 线索转化为客户后，不修改线索状态为 Converted
+	def update_lead_status(self):
+		"""If Customer created from Lead, update lead status to "Converted"
+		update Customer link in Quotation, Opportunity"""
+		if self.lead_name:
+			# frappe.db.set_value("Lead", self.lead_name, "status", "Converted")
+			pass

--- a/erpnext_china_mdm/mdm/custom_permission/lead/permission_lead.py
+++ b/erpnext_china_mdm/mdm/custom_permission/lead/permission_lead.py
@@ -26,7 +26,7 @@ def has_permission(doc, user, permission_type=None):
 		users = get_employee_tree(parent=user)
 		users.append(user)
 		# if (doc.owner in users) or (doc.lead_owner in users) or (doc.custom_sea == "公海" and len(frappe.get_all('Has Role', {'parent':user,'role': ['in', ['网络推广', '销售']]})) > 0):
-		if (doc.owner in users) or (doc.lead_owner in users) or (len(frappe.get_all('Has Role', {'parent':user,'role': ['in', ['网络推广', '销售']]})) > 0) or (doc.custom_sea == '公海'):
+		if (doc.owner in users) or (doc.lead_owner in users) or (doc.custom_sea == '公海'):
 			return True
 		else:
 			return False


### PR DESCRIPTION
1. 线索上级看下级，自己看自己，所有看公海。修复网推和销售可以通过线索详情链接看到别人的线索内容。
2. 线索创建客户后，状态不再改变为 已转化，而是保持不变