### PR TITLE
✨ feat(销售订单定制):

### DIFF
--- a/erpnext_china_mdm/hooks.py
+++ b/erpnext_china_mdm/hooks.py
@@ -239,8 +239,28 @@ after_install = "erpnext_china_mdm.setup.after_install.operations.install_fixtur
 doctype_js = {
     'Address': 'mdm/custom_form_script/address/address.js',
     'Customer': 'mdm/custom_form_script/customer/customer.js',
-    'Item': 'mdm/custom_form_script/item/item.js'
+    'Item': 'mdm/custom_form_script/item/item.js',
+	'Sales Order': 'mdm/custom_form_script/sales_order/sales_order.js',
 }
+
+doc_events = {
+	"Sales Order": {
+		"validate": "erpnext_china_mdm.mdm.custom_form_script.sales_order.sales_order.validate_sales_team",
+	}
+}
+
+scheduler_events = {
+	"cron": { 
+        "0 1 * * *": [
+			"erpnext_china_mdm.mdm.custom_form_script.scheduler_events.sales_person.auto_generate_sales_person",
+		],   
+	},
+}
+
+fixtures = [
+    {"dt": "Custom Field", "filters": [["module", "=", "ERPNext China MDM"]]},
+    {"dt": "Property Setter", "filters": [["module", "=", "ERPNext China MDM"]]},
+]
 
 permission_query_conditions = {
     'Customer': "erpnext_china_mdm.mdm.custom_permission.customer.permission_customer.has_query_permission",

--- a/erpnext_china_mdm/mdm/custom_form_script/sales_order/sales_order.js
+++ b/erpnext_china_mdm/mdm/custom_form_script/sales_order/sales_order.js
@@ -1,0 +1,25 @@
+frappe.ui.form.on('Sales Order', {
+    refresh(frm){
+		console.log('refresh')
+		
+        if(!has_common(frappe.user_roles, ["Administrator", "System Manager","Accounts User","Accounts Manager"])){
+			// 销售税费明细子表对除管理员和财务外的其他角色只读，明细中科目和成本中心也只读
+			frm.set_df_property('taxes','read_only',1)
+			frm.fields_dict["taxes"].grid.toggle_enable("account_head", 0)
+			frm.fields_dict["taxes"].grid.toggle_enable("cost_center", 0)
+			
+		}
+
+		if (has_common(frappe.user_roles, ["Administrator", "System Manager","HR User", "HR Manager"])) {
+			// 销售团队、佣金相关字段默认隐藏，高权限用户可见
+			frm.set_df_property('sales_team_section_break','hidden',0)
+			frm.set_df_property('section_break1','hidden',0)
+		}
+
+		if (has_common(frappe.user_roles, ["Administrator", "System Manager"])) {
+			// 销售价格只有管理员可编辑
+			frm.fields_dict["items"].grid.toggle_enable("rate", 1)
+			
+		}
+    },
+});

--- a/erpnext_china_mdm/mdm/custom_form_script/sales_order/sales_order.py
+++ b/erpnext_china_mdm/mdm/custom_form_script/sales_order/sales_order.py
@@ -1,0 +1,36 @@
+import frappe
+
+def validate_sales_team(doc,method=None):
+	if doc.doctype == 'Sales Order' and not doc.sales_team:
+		user = frappe.session.user
+
+		employee = frappe.db.get_value('Employee',{'user_id':user})
+
+
+		if not employee:
+			if user == 'Administrator':
+				# 管理员操作默认选择第一个员工
+				employee_list = frappe.get_all('Employee',pluck='name')
+				if len(employee_list) > 0:
+					employee = employee_list[0]
+					frappe.msgprint('管理员操作默认选择第一个员工',alert=1)
+			else:
+				frappe.throw("当前用户没有员工信息，请完善配置！")
+		frappe.log({'employee':employee})
+		sales_person = frappe.db.get_value('Sales Person',{'employee':employee,})
+
+		if not sales_person:
+			frappe.throw("当前用户没有销售团队配置，请联系管理员！")
+		else:
+			sales_person = frappe.get_doc('Sales Person',sales_person)
+			sales_team = {
+				'parenttype':'Sales Order',
+				'parentfield':'sales_team',
+				'parent':doc.name,
+				'sales_person':sales_person.name,
+				'allocated_percentage':100,
+				'department':sales_person.department,
+				'reports_to':sales_person.reports_to
+			}
+			doc.append('sales_team',sales_team)
+			frappe.log({'sales_team':sales_team,'doc':doc.sales_team})

--- a/erpnext_china_mdm/mdm/custom_form_script/scheduler_events/sales_person.py
+++ b/erpnext_china_mdm/mdm/custom_form_script/scheduler_events/sales_person.py
@@ -1,0 +1,21 @@
+import frappe
+
+def auto_generate_sales_person():
+	roles = ['销售']
+	sales_users = frappe.get_all('Has Role',filters={'role':['in', roles]},pluck='parent')
+	employees = frappe.get_all('Employee',filters={'user_id':['in', sales_users],'status':'Active'},pluck='name')
+	for employee in employees:
+		if not frappe.db.exists("Sales Person", {'employee': employee}):
+			root_node = frappe.get_all('Sales Person',filters={'is_group':1,'enabled':1},order_by='creation',pluck='name')
+			if len(root_node) == 0:
+				frappe.log_error("销售团队根节点不存在，未完成销售人员自动创建")
+				return
+		
+			doc = frappe.new_doc("Sales Person")
+			doc.update({
+				'sales_person_name':employee,
+				'parent_sales_person': root_node[0],
+				'employee': employee, 
+				'sales_team': None
+			})
+			doc.insert().save()


### PR DESCRIPTION
#42 
1、物料明细：价格相关信息，除了管理员以外的角色只读
 2、销售税费明细表：除了管理员以外的角色只读
 3、“更多信息”栏中的佣金和销售团队字段只对HR可见，自动重复，打印设置隐藏。状态保留可见状态
 4、销售团队为空时，自动增加当前用户对应的员工所属销售人员信息
 5、新建一个定时任务，每天凌晨触发，检查所有无销售人员归属的销售，自动创建销售人员。销售人员显示为员工姓名，下拉中增加部门显示
 6、销售团队子表增加部门，上级工号，上级姓名字段，在子表中显示